### PR TITLE
Fix help output

### DIFF
--- a/src/backend/commands/admin.go
+++ b/src/backend/commands/admin.go
@@ -54,6 +54,7 @@ Usage: skeleton admin [options] ...
     Controls users
 
 Available options:
-    make-admin [username]  make a user an admin   
+    make-admin [username]  make a user an admin
+    activate-user [username]  activate a user account
 `)
 }

--- a/src/backend/commands/dev.go
+++ b/src/backend/commands/dev.go
@@ -94,6 +94,6 @@ Usage: skeleton dev [options] ...
 
 Available options:
     new-user  generate a user
-    del-user  delete a user
+    del-user [username]  delete a user
 `)
 }

--- a/src/backend/commands/dev.go
+++ b/src/backend/commands/dev.go
@@ -94,5 +94,6 @@ Usage: skeleton dev [options] ...
 
 Available options:
     new-user  generate a user
+    del-user  delete a user
 `)
 }


### PR DESCRIPTION
## Summary
- ensure dev and admin help screens mention the supported commands

## Testing
- `go test ./...` *(fails: no route to host)*