### PR TITLE
Fix vue loader name in nuxt config

### DIFF
--- a/src/frontend/src/nuxt.config.js
+++ b/src/frontend/src/nuxt.config.js
@@ -168,7 +168,7 @@ export default {
     */
     // cssSourceMap: false,
     loaders: {
-      vus: { cacheBusting: true },
+      vue: { cacheBusting: true },
       scss: { sourceMap: false }
     },
     extend (config, ctx) {


### PR DESCRIPTION
## Summary
- correct the loader name in `nuxt.config.js`

## Testing
- `go test ./... -count=1 | sort -u` *(fails: no route to host)*
- `yarn test` *(fails: package missing from lockfile)*