### PR TITLE
Add auth/login dispatch test

### DIFF
--- a/src/frontend/src/pages/auth/__tests__/login.spec.js
+++ b/src/frontend/src/pages/auth/__tests__/login.spec.js
@@ -74,12 +74,15 @@ describe('login.vue', () => {
     await w.vm.$nextTick()
 
     expect(actions['auth/login']).toHaveBeenCalledTimes(1)
-    expect(actions['auth/login'].mock.calls[0][1]).toEqual({
-      username: 'user1',
-      password: md5('pass1'),
-      code: '',
-      rememberMe: false
-    })
+    expect(actions['auth/login']).toHaveBeenCalledWith(
+      expect.any(Object),
+      {
+        username: 'user1',
+        password: md5('pass1'),
+        code: '',
+        rememberMe: false
+      }
+    )
 
     w.destroy()
   })

--- a/src/frontend/src/pages/auth/__tests__/login.spec.js
+++ b/src/frontend/src/pages/auth/__tests__/login.spec.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import Vuex from 'vuex'
 import VueRouter from 'vue-router'
 import Vuetify from 'vuetify'
+import md5 from 'md5'
 import Login from '../login'
 
 const vuetify = new Vuetify()
@@ -15,7 +16,7 @@ describe('login.vue', () => {
       'page/title': jest.fn(),
       'loading/start': jest.fn(),
       'loading/finish': jest.fn(),
-      'auth/login': jest.fn()
+      'auth/login': jest.fn(() => Promise.resolve())
     }
     store = new Vuex.Store({
       actions,
@@ -54,6 +55,32 @@ describe('login.vue', () => {
     expect(w.vm.$route.path).toEqual('/dashboard/home/')
     expect(w.find('.v-alert__content > div').text())
       .toBe('Successfully logged in!')
+    w.destroy()
+  })
+
+  it('dispatches auth/login with credentials', async () => {
+    const router = new VueRouter({})
+    const w = mount(Login, {
+      store,
+      router,
+      stubs: ['router-link', 'router-view'],
+      vuetify
+    })
+
+    w.find('[data-username]').setValue('user1')
+    w.find('[data-password]').setValue('pass1')
+    w.find('form').trigger('submit.prevent')
+    await w.vm.$nextTick()
+    await w.vm.$nextTick()
+
+    expect(actions['auth/login']).toHaveBeenCalledTimes(1)
+    expect(actions['auth/login'].mock.calls[0][1]).toEqual({
+      username: 'user1',
+      password: md5('pass1'),
+      code: '',
+      rememberMe: false
+    })
+
     w.destroy()
   })
 })

--- a/src/frontend/src/pages/auth/__tests__/login.spec.js
+++ b/src/frontend/src/pages/auth/__tests__/login.spec.js
@@ -16,7 +16,7 @@ describe('login.vue', () => {
       'page/title': jest.fn(),
       'loading/start': jest.fn(),
       'loading/finish': jest.fn(),
-      'auth/login': jest.fn(() => Promise.resolve())
+      'auth/login': jest.fn().mockResolvedValue()
     }
     store = new Vuex.Store({
       actions,


### PR DESCRIPTION
## Summary
- mock auth/login to return a Promise
- verify auth/login dispatched with username and hashed password

## Testing
- `npx jest --runInBand` *(fails: request to https://registry.npmjs.org/jest failed)*