### PR TITLE
Fix paginator off-by-one

### DIFF
--- a/src/backend/utils/paginator/paginator.go
+++ b/src/backend/utils/paginator/paginator.go
@@ -130,6 +130,8 @@ func (p *Paginator) Slice() {
 	} else if p.Offset > p.Size {
 		p.Offset = p.Size
 	}
+	// Calculate the boundary for slicing. 'end' ensures that the slice does not exceed the array bounds,
+	// preventing off-by-one errors.
 	end := p.Offset + limit
 	if end > p.Size {
 		end = p.Size

--- a/src/backend/utils/paginator/paginator.go
+++ b/src/backend/utils/paginator/paginator.go
@@ -125,14 +125,14 @@ func (p *Paginator) Slice() {
 	if limit < 0 || limit > p.Size {
 		limit = p.Size
 	}
-	if p.Offset < -1 {
+	if p.Offset < 0 {
 		p.Offset = 0
 	} else if p.Offset > p.Size {
-		p.Offset = limit
+		p.Offset = p.Size
 	}
-	limit += p.Offset + 1
-	if limit > p.Size {
-		limit = p.Size
+	end := p.Offset + limit
+	if end > p.Size {
+		end = p.Size
 	}
-	p.Models = p.Models[p.Offset:limit]
+	p.Models = p.Models[p.Offset:end]
 }

--- a/src/backend/utils/paginator/paginator_test.go
+++ b/src/backend/utils/paginator/paginator_test.go
@@ -1,0 +1,49 @@
+package paginator_test
+
+import (
+	"testing"
+
+	"backend/utils/paginator"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeModels(n int) []interface{} {
+	ms := make([]interface{}, n)
+	for i := 0; i < n; i++ {
+		ms[i] = i
+	}
+	return ms
+}
+
+func TestPaginator_Slice(t *testing.T) {
+	ms := makeModels(10)
+
+	// page 1 limit 5
+	p := paginator.NewPaginator(map[string]int{"after": 1, "size": 5}, "", "", "/items")
+	p.Models = ms
+	p.Slice()
+	assert.Equal(t, 5, len(p.Models))
+	assert.Equal(t, 0, p.Models[0].(int))
+	assert.Equal(t, 4, p.Models[4].(int))
+
+	// page 2 limit 5
+	p = paginator.NewPaginator(map[string]int{"after": 2, "size": 5}, "", "", "/items")
+	p.Models = ms
+	p.Slice()
+	assert.Equal(t, 5, len(p.Models))
+	assert.Equal(t, 5, p.Models[0].(int))
+	assert.Equal(t, 9, p.Models[4].(int))
+
+	// page 4 limit 3 => last page should have 1 item
+	p = paginator.NewPaginator(map[string]int{"after": 4, "size": 3}, "", "", "/items")
+	p.Models = ms
+	p.Slice()
+	assert.Equal(t, 1, len(p.Models))
+	assert.Equal(t, 9, p.Models[0].(int))
+
+	// limit -1 should return all models
+	p = paginator.NewPaginator(map[string]int{"after": 1, "size": -1}, "", "", "/items")
+	p.Models = ms
+	p.Slice()
+	assert.Equal(t, 10, len(p.Models))
+}


### PR DESCRIPTION
## Summary
- fix off-by-one and overflow issues in `Paginator.Slice`
- add unit tests for paginator slice logic

## Testing
- `go test ./... -count=1 | sort -u` *(fails: no route to host)*