### PR TITLE
Switch deployment from Heroku to Render

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,7 @@
 stages:
   - build-backend
   - build-frontend
-  - create-heroku
   - push-docker
-  - push-heroku
 
 
 variables:
@@ -14,10 +12,6 @@ variables:
   FRONTEND_DIR: "${CI_PROJECT_DIR}/src/frontend"
   BUILD_DIR: "${CI_PROJECT_DIR}/src/backend/build"
   CACHE_DIR: "${CI_PROJECT_DIR}/cache"
-  HEROKU_FILE: "${CI_PROJECT_DIR}/.heroku"
-  HEROKU_APP: "skeleton-${CI_PROJECT_NAMESPACE}"
-  HEROKU_REGISTRY: registry.heroku.com
-  HEROKU_API_KEY: "${HEROKU_API_KEY}"
 
 cache:
   key: ${CI_COMMIT_REF_SLUG}
@@ -78,22 +72,6 @@ frontend:build:
       - $BUILD_DIR
     expire_in: 1 hour
 
-heruko:create:
-  stage: create-heroku
-  cache: {}
-  script:
-    - echo $(heroku auth:token) > $HEROKU_FILE
-    - >
-      heroku create $HEROKU_APP &&
-      heroku addons:create heroku-postgresql:hobby-dev --app $HEROKU_APP &&
-      heroku pg:psql --command='CREATE EXTENSION pg_trgm;' || echo "App already exists"
-    - heroku config:set SKELETON_HOST=$HEROKU_APP.herokuapp.com
-    - heroku config:set SKELETON_FRONTEND=https://$HEROKU_APP.herokuapp.com
-    - heroku config:set PROD_CONFIG_SECRET_FILE=$PROD_CONFIG_SECRET_FILE
-  needs: []
-  artifacts:
-    paths:
-      - $HEROKU_FILE
 
 docker:push:
   stage: push-docker
@@ -114,23 +92,10 @@ docker:push:
     - cp docker/Dockerfile.gitlab "$BUILD_DIR/Dockerfile"
     - cd $BUILD_DIR
     - ls -al
-    - docker login -u _ -p $(cat $HEROKU_FILE) $HEROKU_REGISTRY
-    - docker pull "${HEROKU_REGISTRY}/${HEROKU_APP}/web" || true
-    - docker build --cache-from "${HEROKU_REGISTRY}/${HEROKU_APP}/web"  --tag "${HEROKU_REGISTRY}/${HEROKU_APP}/web" .
-    - docker push "${HEROKU_REGISTRY}/${HEROKU_APP}/web"
-    - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWORD $DOCKER_HUB || true
-    - docker tag "${HEROKU_REGISTRY}/${HEROKU_APP}/web" $DOCKER_HUB_IMAGE_URL:$CI_COMMIT_SHA || true
-    - docker tag "${HEROKU_REGISTRY}/${HEROKU_APP}/web" $DOCKER_HUB_IMAGE_URL:latest || true
-    - docker push $DOCKER_HUB_IMAGE_URL:$CI_COMMIT_SHA || true
-    - docker push $DOCKER_HUB_IMAGE_URL:latest || true
+    - docker build -t $DOCKER_HUB_IMAGE_URL:$CI_COMMIT_SHA .
+    - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWORD $DOCKER_HUB
+    - docker push $DOCKER_HUB_IMAGE_URL:$CI_COMMIT_SHA
+    - docker tag $DOCKER_HUB_IMAGE_URL:$CI_COMMIT_SHA $DOCKER_HUB_IMAGE_URL:latest
+    - docker push $DOCKER_HUB_IMAGE_URL:latest
 
 
-heruko:push:
-  stage: push-heroku
-  only:
-    - master
-  cache: {}
-  script:
-    - cd $BUILD_DIR
-    - BEEGO_RUNMODE=prod CACHE_TYPE=memory DATABASE_URL=$(heroku config:get DATABASE_URL) ./skeleton migrate up
-    - heroku container:release web --app $HEROKU_APP

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <p align="center">
-    <a href="https://skeleton-gadelkareem.herokuapp.com/">
+    <a href="https://skeleton-gadelkareem.onrender.com/">
         <img src="./binary/logo/logo.svg" width="400" alt="Skeleton">
     </a>
 </p>
 
-# [Skeleton](https://skeleton-gadelkareem.herokuapp.com/)
+# [Skeleton](https://skeleton-gadelkareem.onrender.com/)
 [![pipeline status](https://gitlab.com/gadelkareem/skeleton/badges/master/pipeline.svg)](https://gitlab.com/gadelkareem/skeleton/commits/master) <a href="https://github.com/gadelkareem/skeleton"><img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" width="25" height="25" alt="Github Mirror"></a> <a href="https://gitlab.com/gadelkareem/skeleton"><img src="https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png" width="30" height="30" alt="Github Mirror"></a>
 
 
 A complete Golang and Nuxt boilerplate for your project with Subscription management system, backend API, frontend, tests and CI/CD pipelines.
 
-## [Demo](https://skeleton-gadelkareem.herokuapp.com/)
+## [Demo](https://skeleton-gadelkareem.onrender.com/)
 
 ## Features
 - Subscription management system using [Stripe](https://stripe.com/) API.
@@ -31,7 +31,7 @@ A complete Golang and Nuxt boilerplate for your project with Subscription manage
 - [Fully featured admin dashboard](./src/frontend/src/pages/dashboard) based on [Vuetify Material Dashboard](https://demos.creative-tim.com/vuetify-material-dashboard/?partner=116160&ref=vuetifyjs.com#/).
 - [Beautiful home page](./src/frontend/src/pages/index.vue) based on [Veluxi Starter](https://github.com/ilhammeidi/veluxi-starter).
 - [Complete CI/CD pipelines](https://gitlab.com/gadelkareem/skeleton/-/pipelines) including tests using [GitLab .gitlab-ci.yml](.gitlab-ci.yml) file.
-- [Deploy to Heroku](#deploy-to-heroku) using few easy steps.
+- [Deploy to Render](#deploy-to-render) using few easy steps.
 - Automated development initialization using [Docker compose](./docker-compose.yml) and [init file](./init.sh).
 - Application Cache using [Cachita](https://github.com/gadelkareem/cachita) with support for memory, Redis, database and file cache.
 - [Dependency injection](./src/backend/di/Container.go).
@@ -70,16 +70,16 @@ docker exec -it skeleton_backend_1 /bin/bash -c "go test -v ./... -count=1 | sor
 ```
 
 
-## Deploy to Heroku
+## Deploy to Render
 - [Fork the Skeleton repository on Gitlab](https://gitlab.com/gadelkareem/skeleton/-/forks/new)
 - Add the following CI/CD environment variables in [your Gitlab's CI/CD settings section](https://gitlab.com/help/ci/variables/README#custom-environment-variables):
-    - HEROKU_API_KEY: Your free [Heroku API KEY](https://dashboard.heroku.com/account)
-    - PROD_CONFIG_SECRET_FILE (optional): Base64 encoded string of the `./src/backend/conf/app.prod.ini.secret` file. Use the [./src/backend/conf/app.dev.ini.secret.example](./src/backend/conf/app.dev.ini.secret.example) as an example. 
-    ```bash 
+    - PROD_CONFIG_SECRET_FILE (optional): Base64 encoded string of the `./src/backend/conf/app.prod.ini.secret` file. Use the [./src/backend/conf/app.dev.ini.secret.example](./src/backend/conf/app.dev.ini.secret.example) as an example.
+    ```bash
     cat "$PROD_CONFIG_SECRET_FILE" | base64
     ```
 - [Run Gitlab pipeline](https://docs.gitlab.com/ee/ci/pipelines/#run-a-pipeline-manually).
-- Navigate to [your Heroku apps](https://dashboard.heroku.com/apps) to open your app URL.
+- Create a new Web Service on [Render](https://render.com/) and connect it to your repository.
+- Use the provided `render.yaml` to create the required services on Render.
 - For more information, check [.gitlab-ci.yml](.gitlab-ci.yml) to review how the production container is being generated in the pipelines.
 - Optionally you can also push your final image to Docker Hub by adding your username and password as CI/CD environment variables:
     - DOCKER_HUB_USER: docker hub username

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,26 @@
+services:
+  - type: web
+    name: skeleton
+    env: docker
+    dockerfilePath: docker/Dockerfile.gitlab
+    plan: free
+    autoDeploy: true
+    envVars:
+      - key: PROD_CONFIG_SECRET_FILE
+        sync: false
+      - key: DATABASE_URL
+        fromDatabase:
+          name: skeleton-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: skeleton-redis
+          property: connectionString
+
+  - type: redis
+    name: skeleton-redis
+    plan: free
+
+  - type: psql
+    name: skeleton-db
+    plan: free

--- a/src/backend/conf/app.default.ini
+++ b/src/backend/conf/app.default.ini
@@ -18,8 +18,8 @@ AccessLogs = true
 SessionOn = false
 copyrequestbody = true
 
-host = skeleton-gadelkareem.herokuapp.com
-frontEndURL = https://skeleton-gadelkareem.herokuapp.com
+host = skeleton-gadelkareem.onrender.com
+frontEndURL = https://skeleton-gadelkareem.onrender.com
 
 apiPath = /api/v1
 
@@ -35,6 +35,6 @@ disableCache = true
 [smtp]
 server = smtp.mailgun.org
 port = 587
-senderEmail = sender@skeleton-gadelkareem.herokuapp.com
+senderEmail = sender@skeleton-gadelkareem.onrender.com
 senderIdentity = Skeleton Mailer
 

--- a/src/backend/conf/app.dev.ini
+++ b/src/backend/conf/app.dev.ini
@@ -22,7 +22,7 @@ hmacKey = 70dd5aea9533a998dccbcd8809623291861aae550941673a18dd4e3b6adb8010
 [smtp]
 server = 127.0.0.1
 port = 1025
-senderEmail = sender@skeleton-gadelkareem.herokuapp.com
+senderEmail = sender@skeleton-gadelkareem.onrender.com
 senderIdentity = Skeleton Mailer
 
 
@@ -30,7 +30,7 @@ senderIdentity = Skeleton Mailer
 ;[smtp]
 ;server = smtp.mailtrap.io
 ;port = 2525
-;senderEmail = sender@skeleton-gadelkareem.herokuapp.com
+;senderEmail = sender@skeleton-gadelkareem.onrender.com
 ;senderIdentity = Skeleton Mailer
 ;smtpUser =
 ;smtpPassword =

--- a/src/backend/conf/app.prod.ini
+++ b/src/backend/conf/app.prod.ini
@@ -7,8 +7,8 @@ AccessLogs = true
 AccessLogsFormat = JSON_FORMAT
 
 
-host = skeleton-gadelkareem.herokuapp.com
-frontEndURL = https://skeleton-gadelkareem.herokuapp.com
+host = skeleton-gadelkareem.onrender.com
+frontEndURL = https://skeleton-gadelkareem.onrender.com
 
 redisPoolSize = 1
 

--- a/src/backend/conf/app.staging.ini
+++ b/src/backend/conf/app.staging.ini
@@ -22,7 +22,7 @@ hmacKey = 70dd5aea9533a998dccbcd8809623291861aae550941673a18dd4e3b6adb8010
 [smtp]
 server = 127.0.0.1
 port = 1025
-senderEmail = sender@skeleton-gadelkareem.herokuapp.com
+senderEmail = sender@skeleton-gadelkareem.onrender.com
 senderIdentity = Skeleton Mailer
 
 

--- a/src/backend/conf/app.test.ini
+++ b/src/backend/conf/app.test.ini
@@ -22,7 +22,7 @@ hmacKey = 70dd5aea9533a998dccbcd8809623291861aae550941673a18dd4e3b6adb8010
 [smtp]
 server = 127.0.0.1
 port = 1025
-senderEmail = sender@skeleton-gadelkareem.herokuapp.com
+senderEmail = sender@skeleton-gadelkareem.onrender.com
 senderIdentity = Skeleton Mailer
 
 

--- a/src/backend/controllers/CommonController_test.go
+++ b/src/backend/controllers/CommonController_test.go
@@ -15,7 +15,7 @@ func TestCommonController_Contact(t *testing.T) {
 	sub := fmt.Sprintf("[Contact] Message from %s", r.Name)
 	tests.ExpectEmail(t,
 		"",
-		[]string{"sender@skeleton-gadelkareem.herokuapp.com"},
+		[]string{"sender@skeleton-gadelkareem.onrender.com"},
 		sub,
 		"")
 

--- a/src/backend/kernel/App.go
+++ b/src/backend/kernel/App.go
@@ -53,7 +53,7 @@ var (
 		"::1",
 	}
 	allowedHosts = []string{
-		"skeleton-gadelkareem.herokuapp.com",
+		"skeleton-gadelkareem.onrender.com",
 	}
 )
 

--- a/src/frontend/src/components/home/Feature/MainFeature.vue
+++ b/src/frontend/src/components/home/Feature/MainFeature.vue
@@ -30,7 +30,7 @@
             Dev env & CI/CD included
           </h5>
           <p class="body-1">
-            Automated development initialization using Docker compose and init file. Complete CI/CD pipelines including tests using GitLab .gitlab-ci.yml file. Deploy to Heroku using few easy steps.
+            Automated development initialization using Docker compose and init file. Complete CI/CD pipelines including tests using GitLab .gitlab-ci.yml file. Deploy to Render using few easy steps.
           </p>
         </div>
       </v-col>

--- a/src/frontend/src/components/home/Feature/MainFeature.vue
+++ b/src/frontend/src/components/home/Feature/MainFeature.vue
@@ -30,7 +30,7 @@
             Dev env & CI/CD included
           </h5>
           <p class="body-1">
-            Automated development initialization using Docker compose and init file. Complete CI/CD pipelines including tests using GitLab .gitlab-ci.yml file. Deploy to Render using few easy steps.
+            Automated development initialization using Docker compose and init file. Complete CI/CD pipelines including tests using GitLab .gitlab-ci.yml file. Deploy to Render using a few easy steps.
           </p>
         </div>
       </v-col>

--- a/src/frontend/src/pages/legal/__tests__/__snapshots__/privacy-policy.spec.js.snap
+++ b/src/frontend/src/pages/legal/__tests__/__snapshots__/privacy-policy.spec.js.snap
@@ -16,9 +16,9 @@ exports[`invoices.vue should match snapshot 1`] = `
         user of this site.
         <ul>
           <li><b>Us, We, Our</b> - Skeleton is the publisher and
-            operator of the web site&nbsp;<a href="/">http://skeleton-gadelkareem.herokuapp.com</a>,
-            and is referred to as “skeleton-gadelkareem.herokuapp.com”. “us”, “we”, “our”, “ours”,
-            etc. refer to Skeleton Holdings Corporation. “The SITE” or “SITE” refers to&nbsp;<a href="/">http://skeleton-gadelkareem.herokuapp.com</a>.
+            operator of the web site&nbsp;<a href="/">http://skeleton-gadelkareem.onrender.com</a>,
+            and is referred to as “skeleton-gadelkareem.onrender.com”. “us”, “we”, “our”, “ours”,
+            etc. refer to Skeleton Holdings Corporation. “The SITE” or “SITE” refers to&nbsp;<a href="/">http://skeleton-gadelkareem.onrender.com</a>.
           </li>
           <li><b>You, the User</b>&nbsp;- This Policy will refer to the user as “you” or “yours”, etc.
           </li>
@@ -256,7 +256,7 @@ exports[`invoices.vue should match snapshot 1`] = `
     </h2>
     <p>
       We may send you periodic announcements including the details of our existing and new programs.
-      You may opt out of these announcements by contacting&nbsp;<a href="mailto:remove@skeleton-gadelkareem.herokuapp.com">remove@skeleton-gadelkareem.herokuapp.com</a>&nbsp;or
+      You may opt out of these announcements by contacting&nbsp;<a href="mailto:remove@skeleton-gadelkareem.onrender.com">remove@skeleton-gadelkareem.onrender.com</a>&nbsp;or
       by clicking the opt-out link at the bottom of these emails. If you opt out of these marketing
       emails, you may still receive system notices and other information that is specifically related
       to your account.

--- a/src/frontend/src/pages/legal/privacy-policy.vue
+++ b/src/frontend/src/pages/legal/privacy-policy.vue
@@ -25,9 +25,9 @@
           <ul>
             <li>
               <b>Us, We, Our</b> - Skeleton is the publisher and
-              operator of the web site&nbsp;<a href="/">http://skeleton-gadelkareem.herokuapp.com</a>,
-              and is referred to as “skeleton-gadelkareem.herokuapp.com”. “us”, “we”, “our”, “ours”,
-              etc. refer to Skeleton Holdings Corporation. “The SITE” or “SITE” refers to&nbsp;<a href="/">http://skeleton-gadelkareem.herokuapp.com</a>.
+              operator of the web site&nbsp;<a href="/">http://skeleton-gadelkareem.onrender.com</a>,
+              and is referred to as “skeleton-gadelkareem.onrender.com”. “us”, “we”, “our”, “ours”,
+              etc. refer to Skeleton Holdings Corporation. “The SITE” or “SITE” refers to&nbsp;<a href="/">http://skeleton-gadelkareem.onrender.com</a>.
             </li>
             <li>
               <b>You, the User</b>&nbsp;- This Policy will refer to the user as “you” or “yours”, etc.
@@ -284,7 +284,7 @@
       </h2>
       <p>
         We may send you periodic announcements including the details of our existing and new programs.
-        You may opt out of these announcements by contacting&nbsp;<a href="mailto:remove@skeleton-gadelkareem.herokuapp.com">remove@skeleton-gadelkareem.herokuapp.com</a>&nbsp;or
+        You may opt out of these announcements by contacting&nbsp;<a href="mailto:remove@skeleton-gadelkareem.onrender.com">remove@skeleton-gadelkareem.onrender.com</a>&nbsp;or
         by clicking the opt-out link at the bottom of these emails. If you opt out of these marketing
         emails, you may still receive system notices and other information that is specifically related
         to your account.

--- a/src/frontend/src/static/text/brand.js
+++ b/src/frontend/src/static/text/brand.js
@@ -6,7 +6,7 @@ const brand = {
     footerText: 'Skeleton, All Rights Reserved 2020',
     logoText: 'Skeleton',
     projectName: 'Skeleton',
-    url: 'skeleton-gadelkareem.herokuapp.com',
+    url: 'skeleton-gadelkareem.onrender.com',
     img: '/static/logo.svg',
     notifMsg:
       'By continuing to use the site, you agree to the use of cookies. more information '


### PR DESCRIPTION
## Summary
- configure GitLab pipeline without Heroku
- update documentation and example site URL to Render
- update frontend and backend configs with Render domain
- update privacy policy and tests
- add Render blueprint for deploying services

## Testing
- `go test -v ./... -count=1 | sort -u` *(fails: no route to host)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*
